### PR TITLE
Fixing filename typo in gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,6 @@
 /phpunit.xml.dist   export-ignore
 /tests              export-ignore
 /.editorconfig      export-ignore
-/.php.cs            export-ignore
+/.php_cs            export-ignore
 /.github            export-ignore
 


### PR DESCRIPTION
Just a quick fix to address a filename typo in the `.gitattributes` file from `.php.cs` to `.php_cs`.

Really enjoying the package training course by the way! It's been very enlightening! 💡 