### PR TITLE
Update indentation for yaml files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,5 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.yml]
+[*.{yml,yaml}]
 indent_size = 2


### PR DESCRIPTION
The official recommended filename extension for YAML files is `.yaml`

Updated `.editorconfig` to set indentation to two for both `.yml` and `.yaml` files.