### PR TITLE
Make vendor name in homepage a placeholder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         ":vendor_name",
         ":package_name"
     ],
-    "homepage": "https://github.com/spatie/:package_name",
+    "homepage": "https://github.com/:vendor_name/:package_name",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
I have updated the `homepage` value in `composer.json` to have the `:vendor_name` placeholder.

In this way the configure script will replace this value automatically.