### PR TITLE
Replace leftover Spatie references during configure-skeleton

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: spatie
-custom: https://spatie.be/open-source/support-us
+github: :vendor_name
+custom: :author_homepage

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,3 +1,3 @@
 # Security Policy
 
-If you discover any security related issues, please email freek@spatie.be instead of using the issue tracker.
+If you discover any security related issues, please email :author_email instead of using the issue tracker.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) Spatie bvba <info@spatie.be>
+Copyright (c) :vendor_name <:author_email>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         {
             "name": ":author_name",
             "email": ":author_email",
-            "homepage": "https://spatie.be",
+            "homepage": ":author_homepage",
             "role": "Developer"
         }
     ],
@@ -47,11 +47,11 @@
     "funding": [
         {
             "type": "github",
-            "url": "https://github.com/sponsors/spatie"
+            "url": "https://github.com/sponsors/:vendor_name"
         },
         {
             "type": "other",
-            "url": "https://spatie.be/open-source/support-us"
+            "url": ":author_homepage"
         }
     ]
 }

--- a/configure-skeleton.sh
+++ b/configure-skeleton.sh
@@ -25,15 +25,18 @@ author_name=$(ask_question "Author name" "$git_name")
 git_email=$(git config user.email)
 author_email=$(ask_question "Author email" "$git_email")
 
+homepage_guess=${echo author_email | awk -F '@' '{print $NF}'//[[:blank:]]/}
+author_homepage=$(ask_question "Author homepage" "$homepage_guess")
+
 username_guess=${author_name//[[:blank:]]/}
 author_username=$(ask_question "Author username" "$username_guess")
 
 current_directory=$(pwd)
 folder_name=$(basename "$current_directory")
 
-vendor_name_unsantized=$(ask_question "Vendor name" "spatie")
+vendor_name_unsantized=$(ask_question "Vendor name" "$author_name")
 package_name=$(ask_question "Package name" "$folder_name")
-package_description=$(ask_question "Package description" "")
+package_description=$(ask_question "Package description" "$package_name")
 
 # convert my-class-title to MyClassTitle - RODO: use to subsctitute ./src/*
 class_name=$(echo "$package_name" | sed 's/[-_]/ /g' | awk '{for(j=1;j<=NF;j++){ $j=toupper(substr($j,1,1)) substr($j,2) }}1' | sed 's/[[:space:]]//g')
@@ -42,7 +45,7 @@ vendor_name_lower_case=`echo "$vendor_name_unsantized" | tr '[:upper:]' '[:lower
 vendor_name="$(tr '[:lower:]' '[:upper:]' <<< ${vendor_name_lower_case:0:1})${vendor_name_lower_case:1}"
 
 echo
-echo -e "Author: $author_name ($author_username, $author_email)"
+echo -e "Author: $author_name ($author_username, $author_email) - $author_homepage"
 echo -e "Package: $package_name <$package_description>"
 
 echo
@@ -61,6 +64,7 @@ for file in $files ; do
       sed "s/:author_name/$author_name/g" \
     | sed "s/:author_username/$author_username/g" \
     | sed "s/:author_email/$author_email/g" \
+    | sed "s/:author_homepage/$author_homepage/g" \
     | sed "s/:package_name/$package_name/g" \
     | sed "s/Spatie/$vendor_name/g" \
     | sed "s/Skeleton/$class_name/g" \

--- a/configure-skeleton.sh
+++ b/configure-skeleton.sh
@@ -25,7 +25,8 @@ author_name=$(ask_question "Author name" "$git_name")
 git_email=$(git config user.email)
 author_email=$(ask_question "Author email" "$git_email")
 
-homepage_guess=${echo author_email | awk -F '@' '{print $NF}'//[[:blank:]]/}
+homepage_temp=$(echo $author_email | awk -F '@' '{print $NF}')
+homepage_guess=${homepage_temp//[[:blank:]]/}
 author_homepage=$(ask_question "Author homepage" "$homepage_guess")
 
 username_guess=${author_name//[[:blank:]]/}


### PR DESCRIPTION
While these changes would make things easier for third parties using this template, it does add a layer of complexity for Spatie itself. Hence this PR is mostly a suggestion and it is totally understandable if it is closed instead of merged.

Should you choose to merge it, however, I'd appreciate a suggestion for my terrible scripting on the homepage_guess. Sort of a Shell newbie.

Thank you for your time going through this PR 🙂 