### PR TITLE
Phpunit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         verbose="true"
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    verbose="true"
 >
     <testsuites>
         <testsuite name="Spatie Test Suite">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,11 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
+    executionOrder="random"
+    failOnWarning="true"
+    failOnRisky="true"
+    failOnEmptyTestSuite="true"
+    beStrictAboutOutputDuringTests="true"
     verbose="true"
 >
     <testsuites>


### PR DESCRIPTION


- `executionOrder="random"`: make sure our tests do not depend on each other
- `failOnWarning="true"` & `failOnRisky="true"`: makes the test suite a bit more strict (based on warnings from phpunit)
- `failOnEmptyTestSuite="true"`: makes sure the suite actually contains a test. When you forget an annotation, or have a typo in your test name, then suddenly it's not a test anymore and you code may go untested, without you noticing.
- `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"`: handles auto completion, and validation of our xml file

Source: https://backendtea.com/post/phpunit-beyond-basic-config/