### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,3 @@
 
 All notable changes to `:package_name` will be documented in this file.
 
-## 1.0.0 - 202X-XX-XX
-
-- initial release


### PR DESCRIPTION
Our goal is to automate updating the changelog, so I think we don't need this part. `Stefanzweifel/changelog-updater-action` can update a changelog without a second-level heading. 

Currently, If we don't remove this section and release *0.1.0* for our first release, our changelog will look as follows:

```
## 0.1.0 - 2022-04-12

- initial release

## 1.0.0 - 202X-XX-XX

- initial release
```

I'll apply this change to the `package-skeleton-laravel` if this change is okay. 