### PR TITLE
Update permissions in GitHub Actions workflow to allow pushing changed files to repository

### DIFF
--- a/.github/workflows/fix-php-code-style-issues-cs-fixer.yml
+++ b/.github/workflows/fix-php-code-style-issues-cs-fixer.yml
@@ -2,6 +2,9 @@ name: Check & fix styling
 
 on: [push]
 
+permissions:
+  contents: write
+
 jobs:
   php-cs-fixer:
     runs-on: ubuntu-latest

--- a/.github/workflows/fix-php-code-style-issues-pint.yml
+++ b/.github/workflows/fix-php-code-style-issues-pint.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - '**.php'
 
+permissions:
+  contents: write
+
 jobs:
   php-code-styling:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released]
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update permission of default GITHUB_TOKEN to `contents: write`.

GitHub changed the default permission of the GITHUB_TOKEN to read-only at the beginning of February 2023 on all **new** repositories.[^1]

[^1]: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/