### PR TITLE
Update wrong code style library versions

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -181,7 +181,7 @@ function setupCodeStyleLibrary(string $codeStyleLibrary): void
         );
 
         replace_in_file(__DIR__.'/composer.json', [
-            ':require_dev_codestyle' => '"laravel/pint": "^2.3"',
+            ':require_dev_codestyle' => '"laravel/pint": "^1.0"',
             ':scripts_codestyle' => '"format": "vendor/bin/pint"',
             ':plugins_testing' => '',
         ]);
@@ -196,7 +196,7 @@ function setupCodeStyleLibrary(string $codeStyleLibrary): void
         );
 
         replace_in_file(__DIR__.'/composer.json', [
-            ':require_dev_codestyle' => '"friendsofphp/php-cs-fixer": "^3.13"',
+            ':require_dev_codestyle' => '"friendsofphp/php-cs-fixer": "^3.21.1"',
             ':scripts_codestyle' => '"format": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --allow-risky=yes"',
             ':plugins_testing' => '',
         ]);


### PR DESCRIPTION
Laravel Pint v2 does not exist, so I've changed it to require the [same version as the Laravel skeleton](https://github.com/laravel/laravel/blob/32ecad53a9a59d7ad33dbfd6352a5ea0fd0da2cf/composer.json#L16).

I also changed to the minimum version of CS Fixer that [Pint itself is requiring](https://github.com/laravel/pint/blob/97ac2a48e320a6e7a82c753b335a630751477e9e/composer.json#L26C39-L26C46).