### PR TITLE
Update testing library versions

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -140,9 +140,9 @@ function setupTestingLibrary(string $testingLibrary): void
         );
 
         replace_in_file(__DIR__.'/composer.json', [
-            ':require_dev_testing' => '"pestphp/pest": "^2.0"',
+            ':require_dev_testing' => '"pestphp/pest": "^2.15"',
             ':scripts_testing' => '"test": "vendor/bin/pest",
-        "test-coverage": "vendor/bin/pest --coverage"',
+            "test-coverage": "vendor/bin/pest --coverage"',
             ':plugins_testing' => '"pestphp/pest-plugin": true',
         ]);
     } elseif ($testingLibrary === 'phpunit') {
@@ -162,7 +162,7 @@ function setupTestingLibrary(string $testingLibrary): void
         );
 
         replace_in_file(__DIR__.'/composer.json', [
-            ':require_dev_testing' => '"phpunit/phpunit": "^9.5"',
+            ':require_dev_testing' => '"phpunit/phpunit": "^10.3.2"',
             ':scripts_testing' => '"test": "vendor/bin/phpunit",
             "test-coverage": "vendor/bin/phpunit --coverage"',
             ':plugins_testing,' => '', // We need to remove the comma here as well, since there's nothing to add


### PR DESCRIPTION
Updates the minimum testing library versions in composer.json to [a version of Pest that supports PHP 8.3](https://github.com/pestphp/pest/releases/tag/v2.15.0), and the [minimum version of PHPUnit that Pest itself requires](https://github.com/pestphp/pest/blob/d1aeabc9da94b935845ae489164791b2743566c8/composer.json#L26).

Also fixes some indentation.