### PR TITLE
Add composer ecosystem entry to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,10 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
This PR updates the dependabot configuration to include the composer/php ecosystem, ensuring that all projects created from this template repository have automated updates enabled by default. 