### PR TITLE
Adjust gitignore for PHPUnit 10.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .idea
 .php_cs
 .php_cs.cache
-.phpunit.result.cache
+.phpunit.cache
 build
 composer.lock
 coverage


### PR DESCRIPTION
Since PHPUnit now uses a folder to store results in the cache, we should put it in .gitignore file I guess.