### PR TITLE
Update configure.php

### DIFF
--- a/configure.php
+++ b/configure.php
@@ -60,7 +60,7 @@ function writeln(string $line): void
 
 function run(string $command): string
 {
-    return trim(shell_exec($command));
+    return trim(shell_exec($command) ?? '');
 }
 
 function str_after(string $subject, string $search): string
@@ -209,7 +209,7 @@ $authorName = ask('Author name', $gitName);
 $gitEmail = run('git config user.email');
 $authorEmail = ask('Author email', $gitEmail);
 
-$usernameGuess = explode(':', run('git config remote.origin.url'))[1];
+$usernameGuess = explode(':', run('git config remote.origin.url'))[1] ?? '';
 $usernameGuess = dirname($usernameGuess);
 $usernameGuess = basename($usernameGuess);
 $authorUsername = ask('Author username', $usernameGuess);


### PR DESCRIPTION
When you don't fork but download this package, there is no link to a git remote. This leads to two PHP warnings when running the `configure.php` script:

- Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in .../configure.php on line 63
- PHP Warning:  Undefined array key 1 in .../configure.php on line 212

Adding an empty string as a fallback resolves those warnings.

Thank you for this repo! 😊