### PR TITLE
Update actions/checkout to v6

### DIFF
--- a/.github/workflows/fix-php-code-style-issues-cs-fixer.yml
+++ b/.github/workflows/fix-php-code-style-issues-cs-fixer.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/fix-php-code-style-issues-pint.yml
+++ b/.github/workflows/fix-php-code-style-issues-pint.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/run-tests-pest.yml
+++ b/.github/workflows/run-tests-pest.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests-phpunit.yml
+++ b/.github/workflows/run-tests-phpunit.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: main
 


### PR DESCRIPTION
## Summary

- Update `actions/checkout` from v4/v5 to v6 across all workflow files
- No `actions/cache` references found in workflows, so no changes needed there